### PR TITLE
fix(preflights): add root-portal prefix

### DIFF
--- a/src/preflights.ts
+++ b/src/preflights.ts
@@ -2,7 +2,7 @@ import type { Preflight, PreflightContext } from '@unocss/core'
 import { entriesToCss, toArray } from '@unocss/core'
 import type { Theme } from './theme'
 
-const wxPrefix = ['page,::before,::after']
+const wxPrefix = ['page,root-portal-content,::before,::after']
 const taroPrefix = ['*,::before,::after']
 const uniappPrefix = ['uni-page-body,::before,::after']
 // const defaultPrefix = ['*,::before,::after', '::backdrop']


### PR DESCRIPTION
在微信小程序中的root-portal 中使用css variable时会出现问题,因为css var是根据文档流向上查询的，而root-portal是脱离文档流的，因此需要在preflights 中的wxPrefix添加root-portal-content

具体问题可以查看[代码片段](https://developers.weixin.qq.com/s/tmqdy7m27AO0)